### PR TITLE
Update HAIPS@COLM 2026

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1576,13 +1576,13 @@
   tags: [CRYPTO, SEC, SHOP]
 
 - name: HAIPS
-  description: Workshop on Human-Centered AI Privacy and Security
-  year: 2025
+  description: Workshop on Human-Centered Privacy and Security for Language Models
+  year: 2026
   link: https://haips.com
-  deadline: ["2025-06-20 23:59"]
-  comment: Co-located with ACM CCS 2025
-  date: October 17
-  place: Taipei, Taiwan
+  deadline: ["2026-06-23 23:59"]
+  comment: Co-located with COLM 2026
+  date: October 9
+  place: San Francisco, CA, USA
   tags: [SEC, PRIV, SHOP, USEC]
 
 - name: RICSS


### PR DESCRIPTION
Update the existing HAIPS entry for the 2026 edition (2nd Workshop on Human-Centered Privacy and Security for Language Models, co-located with COLM 2026 in San Francisco on October 9, 2026)